### PR TITLE
Régler le bug de la soustraction

### DIFF
--- a/src/backend/operators.py
+++ b/src/backend/operators.py
@@ -30,7 +30,7 @@ def subtract(a: float, b: float) -> float:
     Returns:
         float: La différence a - b.
     """
-    return b - a
+    return a - b
 
 def multiply(a: float, b: float) -> float:
     """


### PR DESCRIPTION
L'ordre d'opération pour l'opérateur de soustraction était inversé. Cette modification fait passer le test `TestOperators.test_subtract`.

Closes #2 