### PR TITLE
Régler le bug de la multiplication

### DIFF
--- a/src/backend/operators.py
+++ b/src/backend/operators.py
@@ -43,7 +43,7 @@ def multiply(a: float, b: float) -> float:
     Returns:
         float: Le produit de a et b.
     """
-    return a ** b
+    return a * b
 
 def divide(a: float, b: float) -> float:
     """


### PR DESCRIPTION
Le bogue a été fixed en utilisant l'opérateur de multiplication plutôt que l'opérateur d'exposant.

Les tests passent.